### PR TITLE
Fix code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 import unittest
 from unittest import mock
+from urllib.parse import urlparse
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -66,9 +67,9 @@ def patched_requests_get(*args, **kwargs):
 		if kwargs["params"].get("date") and kwargs["params"].get("from") and kwargs["params"].get("to"):
 			if test_exchange_values.get(kwargs["params"]["date"]):
 				return PatchResponse({"result": test_exchange_values[kwargs["params"]["date"]]}, 200)
-	elif args[0].startswith("https://api.frankfurter.app") and kwargs.get("params"):
+	elif urlparse(args[0]).hostname == "api.frankfurter.app" and kwargs.get("params"):
 		if kwargs["params"].get("base") and kwargs["params"].get("symbols"):
-			date = args[0].replace("https://api.frankfurter.app/", "")
+			date = urlparse(args[0]).path.replace("/", "")
 			if test_exchange_values.get(date):
 				return PatchResponse(
 					{"rates": {kwargs["params"].get("symbols"): test_exchange_values.get(date)}}, 200


### PR DESCRIPTION
Fixes [https://github.com/Z-GNN/erpnext/security/code-scanning/8](https://github.com/Z-GNN/erpnext/security/code-scanning/8)

To fix the problem, we need to parse the URL using `urlparse` and then check the hostname to ensure it matches the trusted domain. This approach is more secure as it accurately identifies the domain part of the URL, preventing any bypass attempts through URL manipulation.

- Replace the `startswith` check with a `urlparse` check on the hostname.
- Ensure the hostname matches "api.frankfurter.app" to confirm the URL is from the trusted domain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
